### PR TITLE
fix: collection true missing for oneOrMore in element

### DIFF
--- a/lib/rng/element.rb
+++ b/lib/rng/element.rb
@@ -18,7 +18,7 @@ module Rng
     attribute :mixed, Mixed
     attribute :optional, Optional
     attribute :zeroOrMore, ZeroOrMore
-    attribute :oneOrMore, OneOrMore
+    attribute :oneOrMore, OneOrMore, collection: true
     attribute :anyName, AnyName
     attribute :text, Text
     attribute :empty, Empty

--- a/lib/rng/element.rb
+++ b/lib/rng/element.rb
@@ -5,7 +5,7 @@ require "lutaml/model"
 module Rng
   class Element < Lutaml::Model::Serializable
     attribute :attr_name, :string
-    attribute :name, :string
+    attribute :name, Name
     attribute :ns, :string
     attribute :ns_name, NsName
     attribute :datatypeLibrary, :string

--- a/lib/rng/grammar.rb
+++ b/lib/rng/grammar.rb
@@ -8,7 +8,7 @@ module Rng
     attribute :id, :string
     attribute :ns, :string
     attribute :datatypeLibrary, :string
-    attribute :start, Start
+    attribute :start, Start, collection: true
     attribute :define, Define, collection: true, initialize_empty: true
     attribute :element, Element, collection: true
     attribute :include, Include, collection: true

--- a/lib/rng/group.rb
+++ b/lib/rng/group.rb
@@ -7,6 +7,7 @@ module Rng
     attribute :id, :string
     attribute :ns, :string
     attribute :datatypeLibrary, :string
+    attribute :externalRef, ExternalRef
     attribute :element, Element, collection: true, initialize_empty: true
     attribute :attribute, Attribute, collection: true, initialize_empty: true
     attribute :ref, Ref, collection: true, initialize_empty: true
@@ -53,6 +54,7 @@ module Rng
       map_element "data", to: :data
       map_element "list", to: :list
       map_element "notAllowed", to: :notAllowed
+      map_element "externalRef", to: :externalRef
     end
   end
 end

--- a/lib/rng/include.rb
+++ b/lib/rng/include.rb
@@ -6,6 +6,7 @@ module Rng
   class Include < Lutaml::Model::Serializable
     attribute :href, :string
     attribute :ns, :string
+    attribute :define, Define
     attribute :grammar, Grammar
 
     xml do
@@ -17,6 +18,7 @@ module Rng
         to: { empty: :empty, omitted: :omitted, nil: :nil }
       }
       map_content to: :grammar
+      map_element "define", to: :define
     end
   end
 end


### PR DESCRIPTION
There are three issues mentioned in the related ticket

- [x] Unable to represent `<text/>` elements -> this is fixed in https://github.com/lutaml/lutaml-model/pull/423/commits/6f55966be60e2cd9424c68c44f228d4868632d96
- [x] Broken ordering despite `ordered: true` in elements -> this was due to missing `collection: true` for `oneOrMore` in element.rb (Fixed)
- [ ] Handling XML from external namespaces intermingled in RNG 

for #7 
Related PR in lutaml-model -> https://github.com/lutaml/lutaml-model/pull/423